### PR TITLE
Feature/riot api client #1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,13 @@
-RIOT_API_KEY="RIOT_API KEY 발급 후 입력"
+# Riot API Key (반드시 본인 키로 교체)
+RIOT_API_KEY=your_riot_api_key_here
+
+# Regional routing (match-v5, tft match 등)
+# asia / americas / europe / sea 중 선택
 RIOT_REGION=asia
-RIOT_LOL_PLATFORM=kr
-RIOT_TFT_PLATFORM=ap
-TEST_PUUID="_cveHn_Kpio_bpYVCzAomlBFGZT_gvvwu7P_z6FkULLIS_w6RCrsSAliG0NjrksY1-MkAI-e9i4VHg"
+
+# Platform routing (LoL, TFT)
+# LoL: kr, jp1, eun1, euw1, na1 등
+LOL_PLATFORM=kr
+
+# TFT: riot 문서 기준 platform 코드 (예: ap, kr 등 프로젝트에서 사용할 값)
+TFT_PLATFORM=ap

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+# tests/conftest.py
+
+import os
+import sys
+
+# 프로젝트 루트 디렉토리 경로 (tests의 상위 폴더)
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+
+# sys.path에 루트 디렉토리가 없으면 추가
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)

--- a/tests/test_riot_client.py
+++ b/tests/test_riot_client.py
@@ -1,0 +1,103 @@
+# tests/test_riot_client.py
+
+from __future__ import annotations
+
+from typing import Any, Dict
+from unittest.mock import Mock, patch
+
+import pytest
+from requests import Response
+
+from scripts.riot_client import RiotAPIClient, RiotAPIConfig, RiotAPIError
+
+
+def make_mock_response(
+    status_code: int,
+    json_data: Any = None,
+    headers: Dict[str, str] | None = None,
+) -> Response:
+    resp = Mock(spec=Response)
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    resp.headers = headers or {}
+    resp.text = str(json_data) if json_data is not None else ""
+    resp.json.return_value = json_data
+    return resp  # type: ignore[return-value]
+
+
+def make_client_with_mock_session(mock_session: Mock) -> RiotAPIClient:
+    config = RiotAPIConfig(
+        api_key="dummy-key",
+        region="asia",
+        lol_platform="kr",
+        tft_platform="ap",
+    )
+    client = RiotAPIClient(
+        config=config,
+        session=mock_session,
+        max_retries=2,
+        backoff_factor=0.1,  # 테스트에서는 짧게
+        timeout=1,
+    )
+    return client
+
+
+def test_get_success_single_request():
+    # given
+    mock_session = Mock()
+    mock_response = make_mock_response(200, {"ok": True})
+    mock_session.request.return_value = mock_response
+
+    client = make_client_with_mock_session(mock_session)
+
+    # when
+    data = client.get("/lol/test-endpoint", game="lol")
+
+    # then
+    assert data == {"ok": True}
+    mock_session.request.assert_called_once()
+    _, kwargs = mock_session.request.call_args
+    # method는 키워드 인자로 전달되기 때문에 kwargs로 검증
+    assert kwargs["method"] == "GET"
+    assert "/lol/test-endpoint" in kwargs["url"]
+
+
+def test_retry_on_429_then_success():
+    # given: 첫 번째 응답은 429, 두 번째는 200
+    mock_session = Mock()
+    resp_429 = make_mock_response(429, {"status": "rate-limited"}, headers={})
+    resp_200 = make_mock_response(200, {"ok": True})
+    mock_session.request.side_effect = [resp_429, resp_200]
+
+    client = make_client_with_mock_session(mock_session)
+
+    # when
+    with patch("scripts.riot_client.time.sleep") as sleep_mock:
+        data = client.get("/lol/test-endpoint", game="lol")
+
+    # then
+    assert data == {"ok": True}
+    assert mock_session.request.call_count == 2
+    sleep_mock.assert_called_once()  # 백오프 호출 확인
+
+
+def test_retry_exceeds_max_raises_error():
+    # given: 3번 모두 503 응답 (max_retries=2 → 총 3회 시도 후 실패)
+    mock_session = Mock()
+    resp_503 = make_mock_response(503, {"status": "server-error"}, headers={})
+    mock_session.request.side_effect = [resp_503, resp_503, resp_503]
+
+    client = make_client_with_mock_session(mock_session)
+
+    # when / then
+    with patch("scripts.riot_client.time.sleep"):
+        with pytest.raises(RiotAPIError):
+            client.get("/lol/test-endpoint", game="lol")
+
+
+def test_invalid_game_raises_value_error():
+    mock_session = Mock()
+    client = make_client_with_mock_session(mock_session)
+
+    with pytest.raises(ValueError):
+        client.get("/lol/test-endpoint", game="valorant")


### PR DESCRIPTION
Closes #1

## ✨ 목적

Riot Multi-Game Persona Platform에서 공통으로 사용할 Riot API 클라이언트를 구현했습니다.  
이 모듈은 이후 LoL/TFT 매치 수집 및 Feature/Persona 파이프라인에서 재사용됩니다.

---

## 🔧 주요 변경 사항

### 1. Riot API 클라이언트

- `scripts/riot_client.py`
  - `RiotAPIConfig`
    - `RIOT_API_KEY`, `RIOT_REGION`, `LOL_PLATFORM`, `TFT_PLATFORM`을 환경 변수에서 로딩
    - 미설정 시 `ValueError` 발생
  - `RiotAPIClient`
    - `Session`에 `X-Riot-Token` 헤더 설정
    - `region_base_url`, `platform_base_urls["lol" / "tft"]` 구성
    - `_request_with_retry()`
      - 429 / 5xx 응답 시 exponential backoff + 재시도
      - 최대 재시도 초과 시 `RiotAPIError` 발생
    - `get()` 헬퍼
      - `use_region=True` 또는 `game="lol"/"tft"` 에 따라 base URL 선택
    - 편의 메서드
      - `get_lol_match_ids_by_puuid(puuid, count)`
      - `get_lol_match_by_id(match_id)`
      - `get_tft_match_ids_by_puuid(puuid, count)`
      - `get_tft_match_by_id(match_id)`

### 2. 테스트 및 환경 설정

- `tests/test_riot_client.py`
  - 정상 응답 시 1회 호출 여부 검증
  - 429 응답 후 성공 응답으로 재시도되는지 검증
  - 503 연속 응답 시 `RiotAPIError` 발생 검증
  - 잘못된 game 파라미터(`valorant`) 사용 시 `ValueError` 발생 검증

- `tests/conftest.py`
  - pytest 실행 시 프로젝트 루트를 `sys.path`에 추가하여 `scripts` 패키지 인식 문제 해결

---

## ✅ 테스트

```bash
pytest
# 결과: 4 passed
```
![test_riot_client py](https://github.com/user-attachments/assets/b3cd0ed0-3a1b-4ef3-ab6f-a60755d2ee05)
